### PR TITLE
chore: remove checksum address warning

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,9 @@ export function validateSolidityTypeInstance(value: JSBI, solidityType: Solidity
 export function validateAndParseAddress(address: string): string {
   try {
     const checksummedAddress = getAddress(address)
-    warning(address === checksummedAddress, `${address} is not checksummed.`)
+    if ('production' !== process.env.NODE_ENV) {
+      warning(address === checksummedAddress, `${address} is not checksummed.`)
+    }
     return checksummedAddress
   } catch (error) {
     invariant(false, `${address} is not a valid address.`)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,9 +14,6 @@ export function validateSolidityTypeInstance(value: JSBI, solidityType: Solidity
 export function validateAndParseAddress(address: string): string {
   try {
     const checksummedAddress = getAddress(address)
-    if ('production' !== process.env.NODE_ENV) {
-      warning(address === checksummedAddress, `${address} is not checksummed.`)
-    }
     return checksummedAddress
   } catch (error) {
     invariant(false, `${address} is not a valid address.`)


### PR DESCRIPTION
Remove checksum address warning.

Console is flooded with these warnings which aren't helpful.
```
Warning: 0x111111111117dc0aa78b770fa6a738034120c302 is not checksummed.
Warning: 0xff20817765cb7f73d4bde2e66e067e58d11095c2 is not checksummed.
Warning: 0x111111111117dc0aa78b770fa6a738034120c302 is not checksummed.
...
```